### PR TITLE
Removed unnecessary code

### DIFF
--- a/src/com/sun/pdfview/font/BuiltinFont.java
+++ b/src/com/sun/pdfview/font/BuiltinFont.java
@@ -106,11 +106,6 @@ public class BuiltinFont extends Type1Font {
         super(baseFont, fontObj, descriptor);
 
         String fontName = descriptor.getFontName();
-        
-        //check if font is 'PostScript' version of font
-        if(fontName.contains("PSMT")) {
-        	fontName = fontName.replace("PSMT", "");
-        }
 
         // check if it's one of the 14 base fonts
         for (int i = 0; i < baseFonts.length; i++) {


### PR DESCRIPTION
The removed code is a left over and should be removed since it doesn't really work except for the TimesNewRomanPSMT and now this font will be mapped to Times-Roman.